### PR TITLE
[guacamole]: Take down 20211107 OFFICIAL build

### DIFF
--- a/arrow-12.0_gapps_builds_official.json
+++ b/arrow-12.0_gapps_builds_official.json
@@ -34,15 +34,15 @@
     "guacamole": [
         {
             "changelog": "- Bug fixes and stability improvements.", 
-            "date": "2021-11-07", 
-            "datetime": "20211107", 
-            "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211107-GAPPS.zip", 
-            "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211107-GAPPS.zip", 
+            "date": "2021-11-05", 
+            "datetime": "20211105", 
+            "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211105-GAPPS.zip", 
+            "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211105-GAPPS.zip", 
             "maintainer": "alk3p", 
             "model": "GM1917", 
             "oem": "OnePlus", 
-            "sha256": "b64594e6446b60f6bb64c2e97c42082fb96e4b1d36fc16c2cc84a12bbafe50d7", 
-            "size": "1066168799", 
+            "sha256": "dae042a8d43c9381d0a52e2eafb5f921ca6a36dc6cee16da4e33a75642352c1d", 
+            "size": "1066178961", 
             "type": "official", 
             "version": "v12.0"
         }

--- a/arrow-12.0_vanilla_builds_official.json
+++ b/arrow-12.0_vanilla_builds_official.json
@@ -34,15 +34,15 @@
     "guacamole": [
         {
             "changelog": "- Bug fixes and stability improvements.", 
-            "date": "2021-11-07", 
-            "datetime": "20211107", 
-            "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211107-VANILLA.zip", 
-            "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211107-VANILLA.zip", 
+            "date": "2021-11-05", 
+            "datetime": "20211105", 
+            "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211105-VANILLA.zip", 
+            "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211105-VANILLA.zip", 
             "maintainer": "alk3p", 
             "model": "GM1917", 
             "oem": "OnePlus", 
-            "sha256": "c6fe1a0c79e903fcd4ac145870caaef452531beb4016fea44e174ffd1060cb88", 
-            "size": "780389945", 
+            "sha256": "83f2166ca02a8d6cfa4faa58921b6c2f6c982dc69e41e2a4a504962940c2a48e", 
+            "size": "780265426", 
             "type": "official", 
             "version": "v12.0"
         }

--- a/arrow_ota.json
+++ b/arrow_ota.json
@@ -1775,24 +1775,24 @@
             {
               "GAPPS": [
                 {
-                  "date": "2021-11-07", 
-                  "datetime": "20211107", 
-                  "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211107-GAPPS.zip", 
-                  "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211107-GAPPS.zip", 
-                  "sha256": "b64594e6446b60f6bb64c2e97c42082fb96e4b1d36fc16c2cc84a12bbafe50d7", 
-                  "size": "1066168799", 
+                  "date": "2021-11-05", 
+                  "datetime": "20211105", 
+                  "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211105-GAPPS.zip", 
+                  "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211105-GAPPS.zip", 
+                  "sha256": "dae042a8d43c9381d0a52e2eafb5f921ca6a36dc6cee16da4e33a75642352c1d", 
+                  "size": "1066178961", 
                   "type": "official", 
                   "version": "v12.0"
                 }
               ], 
               "VANILLA": [
                 {
-                  "date": "2021-11-07", 
-                  "datetime": "20211107", 
-                  "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211107-VANILLA.zip", 
-                  "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211107-VANILLA.zip", 
-                  "sha256": "c6fe1a0c79e903fcd4ac145870caaef452531beb4016fea44e174ffd1060cb88", 
-                  "size": "780389945", 
+                  "date": "2021-11-05", 
+                  "datetime": "20211105", 
+                  "filename": "Arrow-v12.0-guacamole-OFFICIAL-20211105-VANILLA.zip", 
+                  "filepath": "/arrow-12.0/guacamole/Arrow-v12.0-guacamole-OFFICIAL-20211105-VANILLA.zip", 
+                  "sha256": "83f2166ca02a8d6cfa4faa58921b6c2f6c982dc69e41e2a4a504962940c2a48e", 
+                  "size": "780265426", 
                   "type": "official", 
                   "version": "v12.0"
                 }


### PR DESCRIPTION
This should be an *experimental* build to test OSS libssrec.
Unfortunately, it's broken and should be taken down asap.

This reverts commit 588da4e, e7e369d.

Signed-off-by: alk3pInjection <webmaster@raspii.tech>