### PR TITLE
Remove b1c1 OTA Packages

### DIFF
--- a/arrow-12.0_gapps_builds_official.json
+++ b/arrow-12.0_gapps_builds_official.json
@@ -63,22 +63,6 @@
             "version": "v12.0"
         }
     ], 
-    "blueline": [
-        {
-            "changelog": null, 
-            "date": "2021-12-01", 
-            "datetime": "20211201", 
-            "filename": "Arrow-v12.0-blueline-OFFICIAL-20211201-GAPPS.zip", 
-            "filepath": "/arrow-12.0/blueline/Arrow-v12.0-blueline-OFFICIAL-20211201-GAPPS.zip", 
-            "maintainer": "ReallySnow", 
-            "model": "Pixel 3", 
-            "oem": "google", 
-            "sha256": "61444b96dd6ce187f1ea559c5135fd8a0bbc4f808e4e0710c45832ed5f0366cf", 
-            "size": "1160734300", 
-            "type": "official", 
-            "version": "v12.0"
-        }
-    ], 
     "cas": [
         {
             "changelog": "Hi, ArrowOS 12.0 :)\r\n\r\n1. Initial releases\r\n2. SeLinux permissive", 
@@ -91,22 +75,6 @@
             "oem": "Xiaomi", 
             "sha256": "81897cc69c8d96246f73d325c7e52e48278b684a5f2fb6035f85036059ec39a1", 
             "size": "1819088988", 
-            "type": "official", 
-            "version": "v12.0"
-        }
-    ], 
-    "crosshatch": [
-        {
-            "changelog": null, 
-            "date": "2021-12-01", 
-            "datetime": "20211201", 
-            "filename": "Arrow-v12.0-crosshatch-OFFICIAL-20211201-GAPPS.zip", 
-            "filepath": "/arrow-12.0/crosshatch/Arrow-v12.0-crosshatch-OFFICIAL-20211201-GAPPS.zip", 
-            "maintainer": "ReallySnow", 
-            "model": "Pixel 3 XL", 
-            "oem": "google", 
-            "sha256": "53fe1bb2d55a96143f3a0c56c115fd953d79bca9c6344907f2b50520973ae627", 
-            "size": "1161113543", 
             "type": "official", 
             "version": "v12.0"
         }

--- a/arrow-12.0_vanilla_builds_official.json
+++ b/arrow-12.0_vanilla_builds_official.json
@@ -63,22 +63,6 @@
             "version": "v12.0"
         }
     ], 
-    "blueline": [
-        {
-            "changelog": null, 
-            "date": "2021-12-01", 
-            "datetime": "20211201", 
-            "filename": "Arrow-v12.0-blueline-OFFICIAL-20211201-VANILLA.zip", 
-            "filepath": "/arrow-12.0/blueline/Arrow-v12.0-blueline-OFFICIAL-20211201-VANILLA.zip", 
-            "maintainer": "ReallySnow", 
-            "model": "Pixel 3", 
-            "oem": "google", 
-            "sha256": "d4a98e270e555df9843395c89f7709d1cd4e68e7c8bc6b6f1ff986e5ec4960e2", 
-            "size": "880093871", 
-            "type": "official", 
-            "version": "v12.0"
-        }
-    ], 
     "cas": [
         {
             "changelog": "Hi, ArrowOS 12.0 :)\r\n\r\n1. Initial releases\r\n2. SeLinux permissive", 
@@ -91,22 +75,6 @@
             "oem": "Xiaomi", 
             "sha256": "cb8d91dd73895034b3f088debd187ecd130d13323209694db823d185c9c29218", 
             "size": "1487379591", 
-            "type": "official", 
-            "version": "v12.0"
-        }
-    ], 
-    "crosshatch": [
-        {
-            "changelog": null, 
-            "date": "2021-12-01", 
-            "datetime": "20211201", 
-            "filename": "Arrow-v12.0-crosshatch-OFFICIAL-20211201-VANILLA.zip", 
-            "filepath": "/arrow-12.0/crosshatch/Arrow-v12.0-crosshatch-OFFICIAL-20211201-VANILLA.zip", 
-            "maintainer": "ReallySnow", 
-            "model": "Pixel 3 XL", 
-            "oem": "google", 
-            "sha256": "4154af3a2ba56e3a58bdd07ede4b70afca8fbf6af7d3fba85ca2f87116ba4ccd", 
-            "size": "880419218", 
             "type": "official", 
             "version": "v12.0"
         }

--- a/arrow_ota.json
+++ b/arrow_ota.json
@@ -851,34 +851,6 @@
       "oem": "google", 
       "v12.0": [
         {
-          "OFFICIAL": [
-            {
-              "GAPPS": [
-                {
-                  "date": "2021-12-01", 
-                  "datetime": "20211201", 
-                  "filename": "Arrow-v12.0-blueline-OFFICIAL-20211201-GAPPS.zip", 
-                  "filepath": "/arrow-12.0/blueline/Arrow-v12.0-blueline-OFFICIAL-20211201-GAPPS.zip", 
-                  "sha256": "61444b96dd6ce187f1ea559c5135fd8a0bbc4f808e4e0710c45832ed5f0366cf", 
-                  "size": "1160734300", 
-                  "type": "official", 
-                  "version": "v12.0"
-                }
-              ], 
-              "VANILLA": [
-                {
-                  "date": "2021-12-01", 
-                  "datetime": "20211201", 
-                  "filename": "Arrow-v12.0-blueline-OFFICIAL-20211201-VANILLA.zip", 
-                  "filepath": "/arrow-12.0/blueline/Arrow-v12.0-blueline-OFFICIAL-20211201-VANILLA.zip", 
-                  "sha256": "d4a98e270e555df9843395c89f7709d1cd4e68e7c8bc6b6f1ff986e5ec4960e2", 
-                  "size": "880093871", 
-                  "type": "official", 
-                  "version": "v12.0"
-                }
-              ]
-            }
-          ], 
           "UNOFFICIAL": [
             {
               "GAPPS": [
@@ -1411,34 +1383,6 @@
       "oem": "google", 
       "v12.0": [
         {
-          "OFFICIAL": [
-            {
-              "GAPPS": [
-                {
-                  "date": "2021-12-01", 
-                  "datetime": "20211201", 
-                  "filename": "Arrow-v12.0-crosshatch-OFFICIAL-20211201-GAPPS.zip", 
-                  "filepath": "/arrow-12.0/crosshatch/Arrow-v12.0-crosshatch-OFFICIAL-20211201-GAPPS.zip", 
-                  "sha256": "53fe1bb2d55a96143f3a0c56c115fd953d79bca9c6344907f2b50520973ae627", 
-                  "size": "1161113543", 
-                  "type": "official", 
-                  "version": "v12.0"
-                }
-              ], 
-              "VANILLA": [
-                {
-                  "date": "2021-12-01", 
-                  "datetime": "20211201", 
-                  "filename": "Arrow-v12.0-crosshatch-OFFICIAL-20211201-VANILLA.zip", 
-                  "filepath": "/arrow-12.0/crosshatch/Arrow-v12.0-crosshatch-OFFICIAL-20211201-VANILLA.zip", 
-                  "sha256": "4154af3a2ba56e3a58bdd07ede4b70afca8fbf6af7d3fba85ca2f87116ba4ccd", 
-                  "size": "880419218", 
-                  "type": "official", 
-                  "version": "v12.0"
-                }
-              ]
-            }
-          ], 
           "UNOFFICIAL": [
             {
               "GAPPS": [


### PR DESCRIPTION
Revert "[crosshatch]: otagen for [OFFICIAL] [GAPPS]"

This reverts commit 2242a7336a90c9dbb5aad6a7c1ec8e1dfd6d988f.

Revert "[crosshatch]: otagen for [OFFICIAL] [VANILLA]"

This reverts commit d47ffb74f45c969810ca7d22c9f2d80d03eb3b97.

Revert "[blueline]: otagen for [OFFICIAL] [GAPPS]"

This reverts commit 78adf627385c794a706135450b09a749f335592c.

Revert "[blueline]: otagen for [OFFICIAL] [VANILLA]"

This reverts commit e0fb7af3bbbd3c533f077cccb6c667015305a2ce.